### PR TITLE
upgrading dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Files and directories created by pub
 .dart_tool/
 .packages
@@ -13,4 +12,3 @@ doc/api/
 
 # Vscode workspace
 *.code-workspace
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 # Files and directories created by pub
 .dart_tool/
 .packages
@@ -12,3 +13,4 @@ doc/api/
 
 # Vscode workspace
 *.code-workspace
+.idea/

--- a/envify/CHANGELOG.md
+++ b/envify/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Upgrade SDK and dependencies
+
 ## 2.0.0
 
 - Migrate to null safety

--- a/envify/example/pubspec.yaml
+++ b/envify/example/pubspec.yaml
@@ -5,11 +5,11 @@ description: An example for envify.
 publish_to: none
 
 environment:
-  sdk: ">=2.8.1 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   envify:
 
 dev_dependencies:
-  build_runner: ^1.10.0
+  build_runner: ^2.0.0
   envify_generator:

--- a/envify/pubspec.yaml
+++ b/envify/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envify
 description: A better way to handle environment variables using `.env` file.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/frencojobs/envify
 
 environment:
@@ -8,6 +8,6 @@ environment:
 
 dev_dependencies:
   lint: ^1.5.1
-  test: ^1.16.0-nullsafety.12
+  test: ^1.16.8
 
 scripts: ../derry.yaml

--- a/envify_generator/CHANGELOG.md
+++ b/envify_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Upgrade SDK and dependencies
+
 ## 2.0.0
 
 - Migrate to null-safety

--- a/envify_generator/example/pubspec.yaml
+++ b/envify_generator/example/pubspec.yaml
@@ -5,11 +5,11 @@ description: An example for envify.
 publish_to: none
 
 environment:
-  sdk: ">=2.8.1 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   envify:
 
 dev_dependencies:
-  build_runner: ^1.10.0
+  build_runner: ^2.0.0
   envify_generator:

--- a/envify_generator/pubspec.yaml
+++ b/envify_generator/pubspec.yaml
@@ -1,15 +1,15 @@
 name: envify_generator
 description: Code generator for envify, a better tool to handle environment variables.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/frencojobs/envify
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ^1.2.0
-  build: ^2.0.0
-  dotenv: ^3.0.0-nullsafety.0
+  analyzer: ^2.0.0
+  build: ^2.0.1
+  dotenv: ^3.0.0
   envify: ^2.0.0
   path: ^1.8.0
   source_gen: ^1.0.0

--- a/envify_generator/pubspec.yaml
+++ b/envify_generator/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   analyzer: ^2.0.0
   build: ^2.0.1
   dotenv: ^3.0.0
-  envify: ^2.0.0
+  envify: ^2.0.1
   path: ^1.8.0
   source_gen: ^1.0.0
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,11 +3,11 @@ version: 0.0.1
 description: An example for envify.
 
 environment:
-  sdk: ">=2.8.1 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   envify:
 
 dev_dependencies:
-  build_runner: ^1.10.0
+  build_runner: ^2.0.0
   envify_generator:


### PR DESCRIPTION
envify is no longer compatible with other builder packages like
* json_serializable
* built_value
* freezed

```sh
Because freezed >=0.14.3 depends on analyzer ^2.0.0 and envify_generator >=2.0.0 depends on analyzer ^1.2.0, version solving failed.
```